### PR TITLE
Wording in Localizable.strings files and About window

### DIFF
--- a/SimpleLoader/Languages/Base.lproj/Localizable.strings
+++ b/SimpleLoader/Languages/Base.lproj/Localizable.strings
@@ -50,7 +50,8 @@
 "close" = "关闭";
 "rights_reserved" = "保留所有权利";
 "contributor1" = "laobamac - 开发者";
-"contributor2" = "perez987 - 提供英语翻译";
+"contributor2" = "perez987 - 部分西班牙语和英语翻译";
+"contributor3" = "Anto65 - 部分意大利语翻译";
 "auto_detect" = "自动检测";
 "language_settings" = "语言设置";
 "language" = "语言";

--- a/SimpleLoader/Languages/en.lproj/Localizable.strings
+++ b/SimpleLoader/Languages/en.lproj/Localizable.strings
@@ -50,8 +50,8 @@
 "close" = "Close";
 "rights_reserved" = "All Rights Reserved";
 "contributor1" = "laobamac - Developer";
-"contributor2" = "perez987 - Partial English translation";
-"contributor3" = "Anto65 - Partial Italian translations";
+"contributor2" = "perez987 - Partial Spanish and English translation";
+"contributor3" = "Anto65 - Partial Italian translation";
 "auto_detect" = "Auto Detect";
 "language_settings" = "Language Settings";
 "language" = "Language";

--- a/SimpleLoader/Languages/es.lproj/Localizable.strings
+++ b/SimpleLoader/Languages/es.lproj/Localizable.strings
@@ -50,8 +50,8 @@
 "close" = "Cerrar";
 "rights_reserved" = "Todos los derechos reservados";
 "contributor1" = "laobamac - Desarrollador";
-"contributor2" = "perez987 - Traducción parcial al inglés";
-"contributor3" = "Anto65 - proporciona algunas traducciones al italiano";
+"contributor2" = "perez987 - Traducción parcial a español e inglés";
+"contributor3" = "Anto65 - Traducción parcial al italiano";
 "auto_detect" = "Detección automática";
 "language_settings" = "Configuración de idioma";
 "language" = "Idioma";

--- a/SimpleLoader/Languages/it.lproj/Localizable.strings
+++ b/SimpleLoader/Languages/it.lproj/Localizable.strings
@@ -15,8 +15,8 @@
 "installation_options" = "Opzioni di installazione";
 "show_advanced" = "Mostra opzioni avanzate";
 "hide_advanced" = "Nascondi opzioni avanzate";
-"force_overwrite" = "Forzare la sovrascrittura dei file esistenti";
-"backup_existing" = "Eseguire il backup di Kext/Framework esistenti";
+"force_overwrite" = "Forza la sovrascrittura dei file esistenti";
+"backup_existing" = "Esegui il backup di Kext/Framework esistenti";
 "advanced_options" = "Opzioni avanzate";
 "install_to_le" = "Installare in /Library/Extensions";
 "install_to_private" = "Consenti installazione Framework in /System/Library/PrivateFrameworks";
@@ -50,8 +50,8 @@
 "close" = "Chiudere";
 "rights_reserved" = "Tutti i diritti riservati";
 "contributor1" = "laobamac - Sviluppatore";
-"contributor2" = "perez987 - Traduzione parziale in inglese";
-"contributor3" = "Anto65 - con traduzione parziale in italiano disponibile";
+"contributor2" = "perez987 - Traduzione parziale in inglese i spagnolo";
+"contributor3" = "Anto65 - Traduzione parziale in italiano";
 "auto_detect" = "Rilevamento automatico";
 "language_settings" = "Configurazione della lingua";
 "language" = "Lingua";

--- a/SimpleLoader/Languages/zh-Hans.lproj/Localizable.strings
+++ b/SimpleLoader/Languages/zh-Hans.lproj/Localizable.strings
@@ -50,8 +50,8 @@
 "close" = "关闭";
 "rights_reserved" = "保留所有权利";
 "contributor1" = "laobamac - 开发者";
-"contributor2" = "perez987 - 提供部分英语翻译";
-"contributor3" = "Anto65 - 提供部分意大利语翻译";
+"contributor2" = "perez987 - 部分西班牙语和英语翻译";
+"contributor3" = "Anto65 - 部分意大利语翻译";
 "auto_detect" = "自动检测";
 "language_settings" = "语言设置";
 "language" = "语言";

--- a/SimpleLoader/Languages/zh-Hant.lproj/Localizable.strings
+++ b/SimpleLoader/Languages/zh-Hant.lproj/Localizable.strings
@@ -50,8 +50,8 @@
 "close" = "關閉";
 "rights_reserved" = "保留所有權利";
 "contributor1" = "laobamac - 開發者";
-"contributor2" = "perez987 - 提供部分英文翻譯";
-"contributor3" = "Anto65 - 提供部分意大利語翻譯";
+"contributor2" = "perez987 - 部分西班牙文和英文翻譯";
+"contributor3" = "Anto65 - 部分義大利文翻譯";
 "auto_detect" = "自動偵測";
 "language_settings" = "語言設定";
 "language" = "語言";

--- a/SimpleLoader/Views/AboutView.swift
+++ b/SimpleLoader/Views/AboutView.swift
@@ -92,7 +92,7 @@ struct AboutView: View {
             .frame(width: 120)
         }
         .padding()
-        .frame(width: 325, height: 425)
+        .frame(width: 355, height: 445)
     }
 }
 


### PR DESCRIPTION
- Minor changes in Localizable.strings files, contributors lines (review Chinese please).
- About window:
  - slightly taller (Close button is stuck to the bottom edge)
  - slightly wider (Spanish All rights reserved does not fit).

Are you Okay with these changes? If so, please merge them before you made more changes to your own repo, thank you.

<img width="330" height="421" alt="About" src="https://github.com/user-attachments/assets/2690890f-399c-4fb0-8709-2451c184c8f6" />


I'm impressed with the instant language switching mechanism in About. I love it, excellent work.
SimpleLoader as it is now is a very nice app, fast to launch, and does what it's supposed to do very well. I don't think you need to expand it much further, so it remains simple and intended for very specific tasks. But that's my choice. You're in charge.
I'm mentioning this because I'm not sure how to implement the patches you're currently working on.

Anyway, I love this app and being able to collaborate with you.